### PR TITLE
Fixed the wrapper to allow calling arguments to override configuration.

### DIFF
--- a/grc.wrap.fish
+++ b/grc.wrap.fish
@@ -1,7 +1,14 @@
 function grc.wrap -a executable
-  set arguments $argv[1..-1]
+  set executable $argv[1]
+  
+  if test (count $argv) -gt 1
+    set arguments $argv[2..(count $argv)]
+  else
+    set arguments
+  end
+
   set optionsvariable "grcplugin_"$executable
   set options $$optionsvariable
 
-  command grc -es --colour=auto $arguments $options
+  command grc -es --colour=auto $executable $options $arguments
 end


### PR DESCRIPTION
This was needed to allow for example, `ls -lh` in the configuration to be overridden to `ls -x` upon call.

This might not be the most effective way to do this since I don't know fish much, but it works.
