### PR TITLE
grc_plugin_execs overrides instead of appends to command list

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ omf install grc
 - `traceroute`
 - `wdiff`
 
-## Options
+## Plugin options
 
 It's possible to define additional command options via universal `grcplugin` variables. For example:
 
@@ -52,6 +52,16 @@ set -U grcplugin_ls --color -l
 ```
 
 Makes `grc` call `ls` with `--color` and `-l` options.
+
+## Override command colorizers
+
+It's possible to override the commands that are colorized via `grc_plugin_execs` variable. For example:
+
+```fish
+set -U grc_plugin_execs gcc g++ make
+```
+
+Enables `grc` colorizing for only `gcc`, `g++` & `make` and disables all others.
 
 # License
 

--- a/grc.fish
+++ b/grc.fish
@@ -9,7 +9,7 @@ function init --on-event init_grc
   end
 
   if set -q grc_plugin_execs
-    set execs $execs $grc_plugin_execs
+    set execs $grc_plugin_execs
   end
 
   for executable in $execs


### PR DESCRIPTION
Changed the universal variable `grc_plugin_execs` to override instead of appending to the list of commands which is wrapped by `grc`.

This change adds the posibility to disable `grc` for specific commands (e.g. `ls` which I'd rather have `dircolors` for than `grc`).
