### PR TITLE
Fix handling of grc_plugin_execs

### DIFF
--- a/conf.d/grc.fish
+++ b/conf.d/grc.fish
@@ -17,8 +17,8 @@ if type -q grc
   if set -q grc_plugin_execs
     if set -q grc_plugin_ignore_execs
       echo "Both grc_plugin_execs and grc_plugin_ignore_execs  have been provided. Ignoring the latter."
-      set execs $grc_plugin_execs
     end
+    set execs $grc_plugin_execs
   end
 
   if set -q grc_plugin_extras


### PR DESCRIPTION
Previously grc_plugin_execs only takes action when grc_plugin_ignore_execs is also set. That does not work as expected.